### PR TITLE
Implement attributes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ $ bash make.sh build_linux
 | ----------------|------------------------------------------------|----------------|
 | Project         | Google Cloud project ID | NONE(required) |
 | Topic           | Google Cloud Pub/Sub topic name | NONE(required) |
-| Format          | The format to encode the message. Supported formats are json and map value | map value(optional) |
+| Format          | The format to encode the message. Supported formats are json and map(only value) | map (optional) |
+| Attributes      | JSON string specifying message attributes | NONE(optional)
 | Debug           | Print debug log | false(optional) |
 | Timeout         | The maximum time that the client will attempt to publish a bundle of messages. (millsecond) | 60000 (optional)|
 | DelayThreshold  | Publish a non-empty batch after this delay has passed. (millsecond) | 1  |
@@ -47,6 +48,7 @@ $ bash make.sh build_linux
     Project your-project(custom)
     Topic your-topic-name(custom)
     Format json
+    Attributes {"key1":"value1","key2":"value2"} 
 ```
 
 ### Example exec

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ bash make.sh build_linux
 | Project         | Google Cloud project ID | NONE(required) |
 | Topic           | Google Cloud Pub/Sub topic name | NONE(required) |
 | Format          | The format to encode the message. Supported formats are json and map(only value) | map (optional) |
-| Attributes      | JSON string specifying message attributes | NONE(optional)
+| Attributes      | JSON string specifying message attributes | NONE(optional) |
 | Debug           | Print debug log | false(optional) |
 | Timeout         | The maximum time that the client will attempt to publish a bundle of messages. (millsecond) | 60000 (optional)|
 | DelayThreshold  | Publish a non-empty batch after this delay has passed. (millsecond) | 1  |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ bash make.sh build_linux
 | ----------------|------------------------------------------------|----------------|
 | Project         | Google Cloud project ID | NONE(required) |
 | Topic           | Google Cloud Pub/Sub topic name | NONE(required) |
-| Format          | The format to encode the message. Supported formats are json and map(only value) | map (optional) |
+| Format          | The type of message to be sent to pubsub. Currently, only `json` is supported. | NONE(optional) |
 | Attributes      | JSON string specifying message attributes | NONE(optional) |
 | Debug           | Print debug log | false(optional) |
 | Timeout         | The maximum time that the client will attempt to publish a bundle of messages. (millsecond) | 60000 (optional)|

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
-module github.com/gjbae1212/fluent-bit-pubsub
+module github.com/st-tech/fluent-bit-pubsub-custom
 
 require (
 	cloud.google.com/go/pubsub v1.40.0
 	github.com/fluent/fluent-bit-go v0.0.0-20230731091245-a7a013e2473c
+	github.com/joho/godotenv v1.5.1
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.9.0
 )
@@ -23,7 +24,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.5 // indirect
-	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect

--- a/pubsub.go
+++ b/pubsub.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Keeper interface {
-	Send(ctx context.Context, data []byte) *pubsub.PublishResult
+	Send(ctx context.Context, data []byte, attributes map[string]string) *pubsub.PublishResult
 	Stop()
 }
 
@@ -45,11 +45,15 @@ func NewKeeper(projectId, topicName string,
 	return Keeper(pubs), nil
 }
 
-func (gps *GooglePubSub) Send(ctx context.Context, data []byte) *pubsub.PublishResult {
+func (gps *GooglePubSub) Send(ctx context.Context, data []byte, attributes map[string]string) *pubsub.PublishResult {
 	if len(data) == 0 {
 		return nil
 	}
-	return gps.topic.Publish(ctx, &pubsub.Message{Data: data})
+	msg := &pubsub.Message{Data: data}
+	if attributes != nil {
+		msg.Attributes = attributes
+	}
+	return gps.topic.Publish(ctx, msg)
 }
 
 func (gps *GooglePubSub) Stop() {

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"os"
 	"testing"
@@ -65,7 +66,19 @@ func TestGooglePubSub_Send(t *testing.T) {
 	keeper, err := NewKeeper(projectId, topicName, nil)
 	assert.NoError(err)
 
-	result := keeper.Send(ctx, []byte("aaa"))
+	data := map[string]interface{}{
+		"key1": "value1",
+		"key2": "value2",
+	}
+
+	attributes := map[string]string{
+		"attr_key1": "attr_value1",
+		"attr_key2": "attr_value2",
+	}
+	msg, err := json.Marshal(data)
+	assert.NoError(err)
+	result := keeper.Send(ctx, msg, attributes)
+
 	_, err = result.Get(ctx)
 	assert.NoError(err)
 	sub := keeper.(*GooglePubSub).client.Subscription(topicName)


### PR DESCRIPTION
## Summary

Added support for custom attributes in Google Pub/Sub messages.

## Changes

1. Added the `Attributes` option to the Fluent Bit configuration, allowing users to specify message attributes in JSON format.
2. Refactored the message creation logic and added attribute handling.
3. Added test cases to ensure correct handling and inclusion of attributes in messages.
4. Updated the README to include the `Attributes` option and provided usage examples.
5. Changed the module name for better project organization and clarity.

## Testing

All new and existing tests have been run to ensure that the changes are functioning as expected.

output:
```
=== RUN   TestEncodeToJSON
=== RUN   TestEncodeToJSON/simple_map
=== RUN   TestEncodeToJSON/nested_map
=== RUN   TestEncodeToJSON/invalid_key_type
=== RUN   TestEncodeToJSON/nested_slice
=== RUN   TestEncodeToJSON/byte_value
=== RUN   TestEncodeToJSON/nested_byte_slice
=== RUN   TestEncodeToJSON/nested_interface
=== RUN   TestEncodeToJSON/deeply_nested_slice
--- PASS: TestEncodeToJSON (0.00s)
    --- PASS: TestEncodeToJSON/simple_map (0.00s)
    --- PASS: TestEncodeToJSON/nested_map (0.00s)
    --- PASS: TestEncodeToJSON/invalid_key_type (0.00s)
    --- PASS: TestEncodeToJSON/nested_slice (0.00s)
    --- PASS: TestEncodeToJSON/byte_value (0.00s)
    --- PASS: TestEncodeToJSON/nested_byte_slice (0.00s)
    --- PASS: TestEncodeToJSON/nested_interface (0.00s)
    --- PASS: TestEncodeToJSON/deeply_nested_slice (0.00s)
=== RUN   TestFLBPluginInit
--- PASS: TestFLBPluginInit (0.01s)
=== RUN   TestFLBPluginFlush
--- PASS: TestFLBPluginFlush (5.53s)
=== RUN   TestInterfaceToBytes
--- PASS: TestInterfaceToBytes (0.00s)
=== RUN   TestNewKeeper
--- PASS: TestNewKeeper (0.03s)
=== RUN   TestGooglePubSub_Send
--- PASS: TestGooglePubSub_Send (5.37s)
=== RUN   TestGooglePubSub_Stop
--- PASS: TestGooglePubSub_Stop (0.02s)
PASS
coverage: 73.3% of statements
ok  	github.com/st-tech/fluent-bit-pubsub-custom	12.321s	coverage: 73.3% of statements
```

## Additional Information

- Please review this PR after the previous one (#5) has been merged.
