### PR TITLE
Implement BufferedByteLimit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # fluent-bit output plugin for google pubsub
 
 <p align="left">    
-  <a href="https://circleci.com/gh/gjbae1212/fluent-bit-pubsub/tree/master"><img src="https://circleci.com/gh/gjbae1212/fluent-bit-pubsub/tree/master.svg?style=svg"/></a>
+
   <a href="https://hits.seeyoufarm.com"/><img src="https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fgjbae1212%2Ffluent-bit-pubsub"/></a>
   <a href="/LICENSE"><img src="https://img.shields.io/badge/license-MIT-GREEN.svg" alt="license" /></a>
   <a href="https://goreportcard.com/report/github.com/gjbae1212/fluent-bit-pubsub"><img src="https://goreportcard.com/badge/github.com/gjbae1212/fluent-bit-pubsub" alt="Go Report Card" /></a>
-  <a href="https://codecov.io/gh/gjbae1212/fluent-bit-pubsub"><img src="https://codecov.io/gh/gjbae1212/fluent-bit-pubsub/branch/master/graph/badge.svg"/></a>        
+
 </p>
 
 This plugin is used to publish data to queue in google pubsub. 
@@ -18,11 +18,11 @@ A bin directory already has been made binaries for mac, linux.
 If you should directly make binaries for mac, linux
 ```bash
 # local machine binary
-$ bash make.sh build
+$ make local-build
 
 # Your machine is mac, and if you should do to retry cross compiling for linux.
 # A command in below is required a docker.  
-$ bash make.sh build_linux
+$ make build-linux
 ```
 
 ## Usage
@@ -33,11 +33,12 @@ $ bash make.sh build_linux
 | Topic           | Google Cloud Pub/Sub topic name | NONE(required) |
 | Format          | The type of message to be sent to pubsub. Currently, only `json` is supported. | NONE(optional) |
 | Attributes      | JSON string specifying message attributes | NONE(optional) |
-| Debug           | Print debug log | false(optional) |
-| Timeout         | The maximum time that the client will attempt to publish a bundle of messages. (millsecond) | 60000 (optional)|
+| Debug           | Print debug log | False(optional) |
+| Timeout         | The maximum time that the client will attempt to publish a bundle of messages. (millsecond) | 60000(optional)|
 | DelayThreshold  | Publish a non-empty batch after this delay has passed. (millsecond) | 1  |
-| ByteThreshold   | Publish a batch when its size in bytes reaches this value. | 1000000 |
-| CountThreshold  | Publish a batch when it has been reached count of messages. | 100  |
+| ByteThreshold   | Publish a batch when its size in bytes reaches this value. | 1000000(optional) |
+| CountThreshold  | Publish a batch when it has been reached count of messages. | 100(optional) |
+| BufferedByteLimit| The maximum number of bytes that the client will buffer before the messages are sent to Pub/Sub.(byte) | 10000000(optional)|
 
 
 ### Example fluent-bit.conf

--- a/output_pubsub_test.go
+++ b/output_pubsub_test.go
@@ -42,6 +42,8 @@ func (o *testOutput) GetConfigKey(ctx unsafe.Pointer, key string) string {
 		return "100"
 	case "Format":
 		return "json"
+	case "BufferedByteLimit":
+		return "1000000"
 	default:
 		return ""
 	}


### PR DESCRIPTION
## Summary

Added support for BufferedByteLimit in Google Pub/Sub messages.

## Changes

1. Added the `BufferedByteLimit` option to the Fluent Bit configuration to allow controlling the buffer size limit.
2. Updated the README to include the `BufferedByteLimit` option.


## Testing

All new and existing tests have been run to ensure that the changes are functioning as expected.

output:
```
=== RUN   TestEncodeToJSON
=== RUN   TestEncodeToJSON/simple_map
=== RUN   TestEncodeToJSON/nested_map
=== RUN   TestEncodeToJSON/invalid_key_type
=== RUN   TestEncodeToJSON/nested_slice
=== RUN   TestEncodeToJSON/byte_value
=== RUN   TestEncodeToJSON/nested_byte_slice
=== RUN   TestEncodeToJSON/nested_interface
=== RUN   TestEncodeToJSON/deeply_nested_slice
--- PASS: TestEncodeToJSON (0.00s)
    --- PASS: TestEncodeToJSON/simple_map (0.00s)
    --- PASS: TestEncodeToJSON/nested_map (0.00s)
    --- PASS: TestEncodeToJSON/invalid_key_type (0.00s)
    --- PASS: TestEncodeToJSON/nested_slice (0.00s)
    --- PASS: TestEncodeToJSON/byte_value (0.00s)
    --- PASS: TestEncodeToJSON/nested_byte_slice (0.00s)
    --- PASS: TestEncodeToJSON/nested_interface (0.00s)
    --- PASS: TestEncodeToJSON/deeply_nested_slice (0.00s)
=== RUN   TestFLBPluginInit
--- PASS: TestFLBPluginInit (0.01s)
=== RUN   TestFLBPluginFlush
--- PASS: TestFLBPluginFlush (5.49s)
=== RUN   TestInterfaceToBytes
--- PASS: TestInterfaceToBytes (0.00s)
=== RUN   TestNewKeeper
--- PASS: TestNewKeeper (0.03s)
=== RUN   TestGooglePubSub_Send
--- PASS: TestGooglePubSub_Send (5.27s)
=== RUN   TestGooglePubSub_Stop
--- PASS: TestGooglePubSub_Stop (0.02s)
PASS
coverage: 73.2% of statements
ok  	github.com/st-tech/fluent-bit-pubsub-custom	12.194s	coverage: 73.2% of statements
```

## Additional Information

None