### PR TITLE
Implement Region option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ $ make build-linux
 | ----------------|------------------------------------------------|----------------|
 | Project         | Google Cloud project ID | NONE(required) |
 | Topic           | Google Cloud Pub/Sub topic name | NONE(required) |
+| Region          | Google Cloud Pub/Sub region (e.g., asia-northeast1, us-central1) | NONE(optional) |
 | Format          | The type of message to be sent to pubsub. Currently, only `json` is supported. | NONE(optional) |
 | Attributes      | JSON string specifying message attributes | NONE(optional) |
 | Debug           | Print debug log | False(optional) |
@@ -48,6 +49,7 @@ $ make build-linux
     Match *
     Project your-project(custom)
     Topic your-topic-name(custom)
+    Region asia-northeast1
     Format json
     Attributes {"key1":"value1","key2":"value2"} 
 ```

--- a/output_pubsub.go
+++ b/output_pubsub.go
@@ -32,6 +32,7 @@ var (
 	byteThreshold     = pubsub.DefaultPublishSettings.ByteThreshold
 	bufferedByteLimit = pubsub.DefaultPublishSettings.BufferedByteLimit
 	debug             = false
+	region            = ""
 )
 
 type Output struct{}
@@ -77,6 +78,7 @@ func FLBPluginInit(ctx unsafe.Pointer) int {
 	ft := wrapper.GetConfigKey(ctx, "Format")
 	ab := wrapper.GetConfigKey(ctx, "Attributes")
 	bbl := wrapper.GetConfigKey(ctx, "BufferedByteLimit")
+	rg := wrapper.GetConfigKey(ctx, "Region")
 
 	// fmt.Printf("[pubsub-go] plugin parameter project = '%s'\n", project)
 	// fmt.Printf("[pubsub-go] plugin parameter topic = '%s'\n", topic)
@@ -88,6 +90,7 @@ func FLBPluginInit(ctx unsafe.Pointer) int {
 	// fmt.Printf("[pubsub-go] plugin parameter format = '%s'\n", ft)
 	// fmt.Printf("[pubsub-go] plugin parameter attributes = '%s'\n", ab)
 	// fmt.Printf("[pubsub-go] plugin parameter buffered byte limit = '%s'\n", bbl)
+	// fmt.Printf("[pubsub-go] plugin parameter region = '%s'\n", rg)
 
 	hostname, err = os.Hostname()
 	if err != nil {
@@ -151,6 +154,9 @@ func FLBPluginInit(ctx unsafe.Pointer) int {
 		}
 		bufferedByteLimit = v
 	}
+	if rg != "" {
+		region = rg
+	}
 	if _, ok := supportFormats[ft]; ok {
 		format = ft
 	} else {
@@ -165,7 +171,7 @@ func FLBPluginInit(ctx unsafe.Pointer) int {
 		BufferedByteLimit: bufferedByteLimit,
 	}
 
-	keeper, err := NewKeeper(project, topic, &publishSetting)
+	keeper, err := NewKeeper(project, topic, region, &publishSetting)
 	if err != nil {
 		fmt.Printf("[err][init] %+v\n", err)
 		return output.FLB_ERROR

--- a/output_pubsub_test.go
+++ b/output_pubsub_test.go
@@ -44,6 +44,8 @@ func (o *testOutput) GetConfigKey(ctx unsafe.Pointer, key string) string {
 		return "json"
 	case "BufferedByteLimit":
 		return "1000000"
+	case "Region":
+		return os.Getenv("REGION")
 	default:
 		return ""
 	}
@@ -97,7 +99,7 @@ func TestFLBPluginFlush(t *testing.T) {
 	if projectId == "" || topicName == "" {
 		return
 	}
-	keeper, err := NewKeeper(projectId, topicName, nil)
+	keeper, err := NewKeeper(projectId, topicName, "", nil)
 	assert.NoError(err)
 	sub := keeper.(*GooglePubSub).client.Subscription(topicName)
 	go func() {

--- a/pubsub.go
+++ b/pubsub.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/pubsub"
+	"google.golang.org/api/option"
 	"github.com/pkg/errors"
 )
 
@@ -18,7 +19,7 @@ type GooglePubSub struct {
 	topic  *pubsub.Topic
 }
 
-func NewKeeper(projectId, topicName string,
+func NewKeeper(projectId, topicName, region string,
 	publishSetting *pubsub.PublishSettings) (Keeper, error) {
 	if projectId == "" || topicName == "" {
 		return nil, fmt.Errorf("[err] NewKeeper empty params")
@@ -27,7 +28,14 @@ func NewKeeper(projectId, topicName string,
 
 	// ADC based authentication
 	// https://cloud.google.com/docs/authentication/application-default-credentials
-	client, err := pubsub.NewClient(ctx, projectId)
+	var opts []option.ClientOption
+	
+	if region != "" {
+		endpoint := fmt.Sprintf("https://%s-pubsub.googleapis.com/", region)
+		opts = append(opts, option.WithEndpoint(endpoint))
+	}
+	
+	client, err := pubsub.NewClient(ctx, projectId, opts...)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "[err] pubsub client")

--- a/pubsub.go
+++ b/pubsub.go
@@ -26,15 +26,15 @@ func NewKeeper(projectId, topicName, region string,
 	}
 	ctx := context.Background()
 
-	// ADC based authentication
-	// https://cloud.google.com/docs/authentication/application-default-credentials
 	var opts []option.ClientOption
 	
 	if region != "" {
-		endpoint := fmt.Sprintf("https://%s-pubsub.googleapis.com/", region)
+		endpoint := fmt.Sprintf("%s-pubsub.googleapis.com:443", region)
 		opts = append(opts, option.WithEndpoint(endpoint))
 	}
 	
+	// ADC based authentication
+	// https://cloud.google.com/docs/authentication/application-default-credentials
 	client, err := pubsub.NewClient(ctx, projectId, opts...)
 
 	if err != nil {

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -21,20 +21,21 @@ func TestNewKeeper(t *testing.T) {
 		t.Log("Error loading .env file")
 	}
 
-	_, err = NewKeeper("", "", nil)
+	_, err = NewKeeper("", "", "", nil)
 	assert.Error(err)
 
 	projectId := os.Getenv("PROJECT_ID")
 	topicName := os.Getenv("TOPIC_NAME")
+	region := os.Getenv("REGION")
 
 	if projectId == "" || topicName == "" {
 		return
 	}
 
-	_, err = NewKeeper(projectId, topicName, nil)
+	_, err = NewKeeper(projectId, topicName, "", nil)
 	assert.NoError(err)
 
-	keeper, err := NewKeeper(projectId, topicName, &pubsub.PublishSettings{
+	keeper, err := NewKeeper(projectId, topicName, region, &pubsub.PublishSettings{
 		ByteThreshold:  10,
 		CountThreshold: 10,
 		DelayThreshold: 1 * time.Second,
@@ -63,7 +64,7 @@ func TestGooglePubSub_Send(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	keeper, err := NewKeeper(projectId, topicName, nil)
+	keeper, err := NewKeeper(projectId, topicName, "", nil)
 	assert.NoError(err)
 
 	data := map[string]interface{}{
@@ -105,7 +106,7 @@ func TestGooglePubSub_Stop(t *testing.T) {
 		return
 	}
 
-	keeper, err := NewKeeper(projectId, topicName, nil)
+	keeper, err := NewKeeper(projectId, topicName, "", nil)
 	assert.NoError(err)
 	keeper.Stop()
 }


### PR DESCRIPTION
# Summary
Region option is now supported in the configuration.
Updated README to document new Region configuration options.
Added test cases to validate the Region option.

# Changes

Updated configuration:
Added Region option to the configuration.

README updates:
Documented new Region configuration options in the README.

Addition of tests:
Added new test cases to validate the Region option.


# Testing

command:

`$ make test`

output:
```
go test -v -race  -coverprofile=coverage.txt -covermode=atomic ./...
=== RUN   TestEncodeToJSON
=== RUN   TestEncodeToJSON/simple_map
=== RUN   TestEncodeToJSON/nested_map
=== RUN   TestEncodeToJSON/invalid_key_type
=== RUN   TestEncodeToJSON/nested_slice
=== RUN   TestEncodeToJSON/byte_value
=== RUN   TestEncodeToJSON/nested_byte_slice
=== RUN   TestEncodeToJSON/nested_interface
=== RUN   TestEncodeToJSON/deeply_nested_slice
--- PASS: TestEncodeToJSON (0.00s)
    --- PASS: TestEncodeToJSON/simple_map (0.00s)
    --- PASS: TestEncodeToJSON/nested_map (0.00s)
    --- PASS: TestEncodeToJSON/invalid_key_type (0.00s)
    --- PASS: TestEncodeToJSON/nested_slice (0.00s)
    --- PASS: TestEncodeToJSON/byte_value (0.00s)
    --- PASS: TestEncodeToJSON/nested_byte_slice (0.00s)
    --- PASS: TestEncodeToJSON/nested_interface (0.00s)
    --- PASS: TestEncodeToJSON/deeply_nested_slice (0.00s)
=== RUN   TestFLBPluginInit
--- PASS: TestFLBPluginInit (0.01s)
=== RUN   TestFLBPluginFlush
--- PASS: TestFLBPluginFlush (6.34s)
=== RUN   TestInterfaceToBytes
--- PASS: TestInterfaceToBytes (0.00s)
=== RUN   TestNewKeeper
--- PASS: TestNewKeeper (0.02s)
=== RUN   TestGooglePubSub_Send
--- PASS: TestGooglePubSub_Send (5.30s)
=== RUN   TestGooglePubSub_Stop
--- PASS: TestGooglePubSub_Stop (0.01s)
PASS
coverage: 74.4% of statements
ok  	github.com/st-tech/fluent-bit-pubsub-custom	13.087s	coverage: 74.4% of statements
```

test publish us-central1

![スクリーンショット 2025-05-20 11 14 51](https://github.com/user-attachments/assets/fb73a4fc-c002-4a0c-b5d5-c0c7ce9089bc)
